### PR TITLE
rails: disable Rails/HttpPositionalArguments for spec/api/*

### DIFF
--- a/rails.yml
+++ b/rails.yml
@@ -18,3 +18,8 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - "db/**/*.rb"
+
+## Rails
+Rails/HttpPositionalArguments:
+  Exclude:
+    - "spec/api/**/*.rb"

--- a/rails.yml
+++ b/rails.yml
@@ -22,4 +22,4 @@ Metrics/MethodLength:
 ## Rails
 Rails/HttpPositionalArguments:
   Exclude:
-    - "spec/api/**/*.rb"
+    - "spec/api/**"

--- a/rubocop-bsm.gemspec
+++ b/rubocop-bsm.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-bsm'
-  spec.version       = '0.5.2'
+  spec.version       = '0.5.3'
   spec.authors       = ['Black Square Media']
   spec.email         = ['info@blacksquaremedia.com']
 


### PR DESCRIPTION
Rails HTTP spec helpers expect calls like `post URL, params: {foo: 'bar'}` but grape/airborne expects `post URL, {foo: 'bar'}`