### PR TITLE
minimal: RSpec/MessageSpies - "receive" style

### DIFF
--- a/minimal.yml
+++ b/minimal.yml
@@ -59,3 +59,5 @@ RSpec/ExampleLength:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/MessageSpies:
+  EnforcedStyle: receive


### PR DESCRIPTION
We mostly use `expect(...).to receive(...)` assertions instead of what else rubocop suggests (`allow(...).to receive(...); expect(...).to have_received(...)` or so)