### PR TITLE
Disabling Cops Rails/NotNullColumn and RSpec/ExpectInHook

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -35,3 +35,5 @@ RSpec/MultipleExpectations:
   Enabled: false
 RSpec/NamedSubject:
   Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false

--- a/rails.yml
+++ b/rails.yml
@@ -23,3 +23,5 @@ Metrics/MethodLength:
 Rails/HttpPositionalArguments:
   Exclude:
     - "spec/api/**"
+Rails/NotNullColumn:
+  Enabled: false

--- a/rubocop-bsm.gemspec
+++ b/rubocop-bsm.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-bsm'
-  spec.version       = '0.5.5'
+  spec.version       = '0.5.6'
   spec.authors       = ['Black Square Media']
   spec.email         = ['info@blacksquaremedia.com']
 


### PR DESCRIPTION
- Rails/NotNullColumn - `add_column ... null: false` in migrations
- RSpec/ExpectInHook - `expect(...)` in `before` etc.